### PR TITLE
Exclude python 3.9 for milestone and devel in sanity test matrix

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -69,12 +69,20 @@ jobs:
               "python-version": "3.8"
             },
             {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
+            },
+            {
               "ansible-version": "devel",
               "python-version": "3.7"
             },
             {
               "ansible-version": "devel",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
             }
           ]
   all_green:


### PR DESCRIPTION
##### SUMMARY
The milestone and devel branches of ansible no longer support python 3.9. This PR adds milestone and devel python 3.9 to `matrix_exclude` in the unit and sanity test Github Actions workflow.

##### ISSUE TYPE
- Bugfix Pull Request