### PR TITLE
Update version to point to the next major release in the galaxy.yml file

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cloud
 name: aws_troubleshooting
-version: 3.0.0-dev0
+version: 4.0.0-dev0
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)


### PR DESCRIPTION
Since stable-3 has been created, update the galaxy.yml version to 4.0.0-dev0.