### PR TITLE
Add new workflow to label prs with needs_triage

### DIFF
--- a/.github/workflows/label-new-prs.yaml
+++ b/.github/workflows/label-new-prs.yaml
@@ -1,7 +1,7 @@
 ---
 name: label new prs
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
SUMMARY

This pr adds a new workflow for labeling new and reopened prs that are not marked as draft. The needs_triage label will be removed if the pr is marked as draft during development and re-added once the pr is marked as ready for review.

After consulting with the team, we decided to label prs in a new workflow to allow for the prs and issues to have different labels in the future.

[ACA-2362](https://issues.redhat.com/browse/ACA-2362)

#### Reported CI Issues
Sanity tests: https://github.com/redhat-cop/cloud.aws_troubleshooting/issues/53 
